### PR TITLE
Spaceapi updates

### DIFF
--- a/SpaceAPI/template.json
+++ b/SpaceAPI/template.json
@@ -2,7 +2,7 @@
   "api": "0.13",
   "space": "Netz39",
   "logo": "http://www.netz39.de/wiki/_media/resources:public_relations:logo:netz39_logo_2013-07-11.png",
-  "url": "http://www.netz39.de",
+  "url": "http://www.netz39.de/",
   "location": {
     "address": "Leibnizstr. 32, 39104 Magdeburg, Germany",
     "lat": 52.119561,
@@ -20,7 +20,7 @@
   },
   "contact": {
     "email": "kontakt@netz39.de",
-    "twitter": "@Netz39",
+    "twitter": "@netz39",
     "ml": "list@netz39.de",
     "irc": "irc://freenode/#netz39"
   },

--- a/SpaceAPI/template.json
+++ b/SpaceAPI/template.json
@@ -29,6 +29,16 @@
     "twitter",
     "ml"
   ],
+  "feeds": {
+    "blog": {
+      "type": "rss",
+      "url": "http://www.netz39.de/feed/"
+    },
+    "calendar": {
+      "type": "ical",
+      "url": "http://www.netz39.de/feed/eo-events/"
+    }
+  },
   "ext_door": {
     "locked": true,
     "open": true,

--- a/SpaceAPI/template.json
+++ b/SpaceAPI/template.json
@@ -22,7 +22,7 @@
     "email": "kontakt@netz39.de",
     "twitter": "@netz39",
     "ml": "list@netz39.de",
-    "irc": "irc://freenode/#netz39"
+    "jabber": "lounge@conference.jabber.n39.eu"
   },
   "issue_report_channels": [
     "email",


### PR DESCRIPTION
Had a look at https://spaceapi.io/ and http://spaceapi.n39.eu/json today and noticed we still publish our ancient IRC room instead of our actually used XMPP MUC. This is fixed by the second patch. The other two … well while I was at it. :wink: 