### PR TITLE
:alien: SpaceApi: Change URL to avoid redirect

### DIFF
--- a/SpaceAPI/template.json
+++ b/SpaceAPI/template.json
@@ -1,7 +1,7 @@
 {
   "api": "0.13",
   "space": "Netz39",
-  "logo": "https://www.netz39.de/wiki/_media/resources:public_relations:logo:netz39_logo_2013-07-11.png",
+  "logo": "https://wiki.netz39.de/_media/resources:public_relations:logo:netz39_logo_2013-07-11.png",
   "url": "https://www.netz39.de/",
   "location": {
     "address": "Leibnizstr. 32, 39104 Magdeburg, Germany",


### PR DESCRIPTION
Our wiki has moved into a container and to another URL. HTTP requests to the old URL are answered with a status code 301 (Moved Permanently). To avoid this request, point directly to the new URL.