### PR TITLE
Fix subscription topics for door and space status lever

### DIFF
--- a/SpaceAPI/update-json.py
+++ b/SpaceAPI/update-json.py
@@ -24,8 +24,8 @@ def on_connect(client, userdata, flags, rc):
 
     # Subscribing in on_connect() means that if we lose the connection and
     # reconnect then subscriptions will be renewed.
-    client.subscribe('/Netz39/Things/Door/Events')
-    client.subscribe('/Netz39/Things/StatusSwitch/Lever/State')
+    client.subscribe('Netz39/Things/Door/Events')
+    client.subscribe('Netz39/Things/StatusSwitch/Lever/State')
 
 
 # The callback for when a PUBLISH message is received from the server.


### PR DESCRIPTION
This pull request includes a small change to the `SpaceAPI/update-json.py` file. The change corrects the MQTT subscription topics by removing the leading slashes from the topic strings.

* [`SpaceAPI/update-json.py`](diffhunk://#diff-b5a1ad7665200467fc706f971a03b71f48e9c13b272eba86127e64986a4d9d9dL27-R28): Corrected MQTT subscription topics by removing leading slashes in `client.subscribe` calls.